### PR TITLE
Support data textures and off-screen rendering

### DIFF
--- a/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
+++ b/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
@@ -57,8 +57,10 @@ class KglAndroid : Kgl {
     }
 
     override fun bindBuffer(target: Int, bufferId: GlBuffer?) = GL.glBindBuffer(target, bufferId ?: 0)
-    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int) {
-        GL.glBufferData(target, size, sourceData.buffer, usage)
+    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int, offset: Int) {
+        sourceData.withIoBuffer(offset) { ioBuffer ->
+            GL.glBufferData(target, size, ioBuffer, usage)
+        }
     }
     override fun deleteBuffer(buffer: GlBuffer) = GL.glDeleteBuffers(1, intArrayOf(buffer), 0)
 
@@ -113,8 +115,10 @@ class KglAndroid : Kgl {
         GLUtils.texImage2D(target, level, internalFormat, bmp, border)
     }
 
-    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
-        GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer.buffer)
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withIoBuffer(offset) { ioBuffer ->
+            GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, ioBuffer)
+        }
     }
 
     override fun activeTexture(texture: Int) = GL.glActiveTexture(texture)
@@ -160,7 +164,9 @@ class KglAndroid : Kgl {
     override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = GL.glIsRenderbuffer(renderbuffer)
     override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = GL.glRenderbufferStorage(target, internalformat, width, height)
 
-    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
-        GL.glReadPixels(x, y, width, height, format, type, buffer.buffer)
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withIoBuffer(offset) { ioBuffer ->
+            GL.glReadPixels(x, y, width, height, format, type, ioBuffer)
+        }
     }
 }

--- a/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
+++ b/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
@@ -113,10 +113,7 @@ class KglAndroid : Kgl {
     }
 
     override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
-        when (buffer) {
-            is java.nio.Buffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
-        }
+        GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer.buffer)
     }
 
     override fun activeTexture(texture: Int) = GL.glActiveTexture(texture)
@@ -152,9 +149,6 @@ class KglAndroid : Kgl {
     override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = GL.glRenderbufferStorage(target, internalformat, width, height)
 
     override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
-        when (buffer) {
-            is java.nio.Buffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
-        }
+        GL.glReadPixels(x, y, width, height, format, type, buffer.buffer)
     }
 }

--- a/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
+++ b/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
@@ -2,6 +2,7 @@ package com.danielgergely.kgl
 
 import android.graphics.BitmapFactory
 import android.opengl.GLES20
+import android.opengl.GLES30
 import android.opengl.GLUtils
 
 typealias GL = GLES20
@@ -120,6 +121,17 @@ class KglAndroid : Kgl {
     override fun bindTexture(target: Int, texture: Texture?) = GL.glBindTexture(target, texture ?: 0)
     override fun generateMipmap(target: Int) = GL.glGenerateMipmap(target)
     override fun texParameteri(target: Int, pname: Int, value: Int) = GL.glTexParameteri(target, pname, value)
+
+    override fun createVertexArray(): VertexArrayObject?
+    {
+        val ints = IntArray(1)
+        GLES30.glGenVertexArrays(1, ints, 0)
+        return ints[0]
+    }
+    override fun bindVertexArray(vertexArrayObject: VertexArrayObject?)
+            = GLES30.glBindVertexArray(vertexArrayObject ?: 0)
+    override fun deleteVertexArray(vertexArrayObject: VertexArrayObject)
+            = GLES30.glDeleteVertexArrays(1, intArrayOf(vertexArrayObject), 0)
 
     override fun drawArrays(mode: Int, first: Int, count: Int) = GL.glDrawArrays(mode, first, count)
 

--- a/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
+++ b/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
@@ -112,6 +112,13 @@ class KglAndroid : Kgl {
         GLUtils.texImage2D(target, level, internalFormat, bmp, border)
     }
 
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
+        when (buffer) {
+            is java.nio.Buffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        }
+    }
+
     override fun activeTexture(texture: Int) = GL.glActiveTexture(texture)
     override fun bindTexture(target: Int, texture: Texture?) = GL.glBindTexture(target, texture ?: 0)
     override fun generateMipmap(target: Int) = GL.glGenerateMipmap(target)
@@ -121,4 +128,33 @@ class KglAndroid : Kgl {
 
     override fun getError(): Int = GL.glGetError()
     override fun finish() = GL.glFinish()
+
+    override fun bindFramebuffer(target: Int, framebuffer: Framebuffer?) = GL.glBindFramebuffer(target, framebuffer ?: 0)
+    override fun createFramebuffer(): Framebuffer? {
+        val ints = IntArray(1)
+        GL.glGenFramebuffers(1, ints, 0)
+        return ints[0]
+    }
+    override fun deleteFramebuffer(framebuffer: Framebuffer) = GL.glDeleteFramebuffers(1, intArrayOf(framebuffer), 0)
+    override fun checkFramebufferStatus(target: Int): Int = GL.glCheckFramebufferStatus(target)
+    override fun framebufferTexture2D(target: Int, attachment: Int, textarget: Int, texture: Texture, level: Int) = GL.glFramebufferTexture2D(target, attachment, textarget, texture, level)
+    override fun isFramebuffer(framebuffer: Framebuffer): Boolean = GL.glIsFramebuffer(framebuffer)
+
+    override fun bindRenderbuffer(target: Int, renderbuffer: Renderbuffer?) = GL.glBindRenderbuffer(target, renderbuffer ?: 0)
+    override fun createRenderbuffer(): Renderbuffer? {
+        val ints = IntArray(1)
+        GL.glGenRenderbuffers(1, ints, 0)
+        return ints[0]
+    }
+    override fun deleteRenderbuffer(renderbuffer: Renderbuffer) = GL.glDeleteRenderbuffers(1, intArrayOf(renderbuffer), 0)
+    override fun framebufferRenderbuffer(target: Int, attachment: Int, renderbuffertarget: Int, renderbuffer: Renderbuffer) = GL.glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
+    override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = GL.glIsRenderbuffer(renderbuffer)
+    override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = GL.glRenderbufferStorage(target, internalformat, width, height)
+
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
+        when (buffer) {
+            is java.nio.Buffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        }
+    }
 }

--- a/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
+++ b/kgl-android/src/main/kotlin/com/danielgergely/kgl/KglAndroid.kt
@@ -126,8 +126,7 @@ class KglAndroid : Kgl {
     override fun generateMipmap(target: Int) = GL.glGenerateMipmap(target)
     override fun texParameteri(target: Int, pname: Int, value: Int) = GL.glTexParameteri(target, pname, value)
 
-    override fun createVertexArray(): VertexArrayObject?
-    {
+    override fun createVertexArray(): VertexArrayObject {
         val ints = IntArray(1)
         GLES30.glGenVertexArrays(1, ints, 0)
         return ints[0]

--- a/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
+++ b/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
@@ -192,8 +192,7 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
 
     override fun texParameteri(target: Int, pname: Int, value: Int) = gl.glTexParameteri(target, pname, value)
 
-    override fun createVertexArray(): VertexArrayObject?
-    {
+    override fun createVertexArray(): VertexArrayObject {
         val ints = IntArray(1)
         gl.glGenVertexArrays(1, ints, 0)
         return ints[0]

--- a/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
+++ b/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
@@ -177,10 +177,7 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
     }
 
     override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
-        when (buffer) {
-            is java.nio.Buffer -> gl.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
-        }
+        gl.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer.buffer)
     }
 
     override fun activeTexture(texture: Int) = gl.glActiveTexture(texture)
@@ -219,10 +216,7 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
     override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = gl.glRenderbufferStorage(target, internalformat, width, height)
 
     override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
-        when (buffer) {
-            is java.nio.Buffer -> gl.glReadPixels(x, y, width, height, format, type, buffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
-        }
+        gl.glReadPixels(x, y, width, height, format, type, buffer.buffer)
     }
 }
 

--- a/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
+++ b/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
@@ -113,8 +113,10 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
 
     override fun bindBuffer(target: Int, bufferId: GlBuffer?) = gl.glBindBuffer(target, bufferId ?: 0)
 
-    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int) {
-        return gl.glBufferData(target, size.toLong(), sourceData.buffer, usage)
+    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int, offset: Int) {
+        sourceData.withIoBuffer(offset) { ioBuffer ->
+            gl.glBufferData(target, size.toLong(), ioBuffer, usage)
+        }
     }
 
     override fun deleteBuffer(buffer: GlBuffer) = gl.glDeleteBuffers(1, intArrayOf(buffer), 0)
@@ -176,8 +178,10 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
         gl.glTexImage2D(target, level, internalFormat, image.width, image.height, border, GL_RGBA, GL_UNSIGNED_BYTE, imageToByteBuffer(image))
     }
 
-    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
-        gl.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer.buffer)
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withIoBuffer(offset) { ioBuffer ->
+            gl.glTexImage2D(target, level, internalFormat, width, height, border, format, type, ioBuffer)
+        }
     }
 
     override fun activeTexture(texture: Int) = gl.glActiveTexture(texture)
@@ -226,8 +230,10 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
     override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = gl.glIsRenderbuffer(renderbuffer)
     override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = gl.glRenderbufferStorage(target, internalformat, width, height)
 
-    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
-        gl.glReadPixels(x, y, width, height, format, type, buffer.buffer)
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withIoBuffer(offset) { glBuffer ->
+            gl.glReadPixels(x, y, width, height, format, type, glBuffer)
+        }
     }
 }
 

--- a/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
+++ b/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
@@ -176,6 +176,13 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
         gl.glTexImage2D(target, level, internalFormat, image.width, image.height, border, GL_RGBA, GL_UNSIGNED_BYTE, imageToByteBuffer(image))
     }
 
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
+        when (buffer) {
+            is java.nio.Buffer -> gl.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        }
+    }
+
     override fun activeTexture(texture: Int) = gl.glActiveTexture(texture)
 
     override fun bindTexture(target: Int, texture: Texture?) = gl.glBindTexture(target, texture ?: 0)
@@ -188,6 +195,35 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
 
     override fun getError(): Int = gl.glGetError()
     override fun finish() = gl.glFinish()
+
+    override fun bindFramebuffer(target: Int, framebuffer: Framebuffer?) = gl.glBindFramebuffer(target, framebuffer ?: 0)
+    override fun createFramebuffer(): Framebuffer? {
+        val ints = IntArray(1)
+        gl.glGenFramebuffers(1, ints, 0)
+        return ints[0]
+    }
+    override fun deleteFramebuffer(framebuffer: Framebuffer) = gl.glDeleteFramebuffers(1, intArrayOf(framebuffer), 0)
+    override fun checkFramebufferStatus(target: Int): Int = gl.glCheckFramebufferStatus(target)
+    override fun framebufferTexture2D(target: Int, attachment: Int, textarget: Int, texture: Texture, level: Int) = gl.glFramebufferTexture2D(target, attachment, textarget, texture, level)
+    override fun isFramebuffer(framebuffer: Framebuffer): Boolean = gl.glIsFramebuffer(framebuffer)
+
+    override fun bindRenderbuffer(target: Int, renderbuffer: Renderbuffer?) = gl.glBindRenderbuffer(target, renderbuffer ?: 0)
+    override fun createRenderbuffer(): Renderbuffer? {
+        val ints = IntArray(1)
+        gl.glGenRenderbuffers(1, ints, 0)
+        return ints[0]
+    }
+    override fun deleteRenderbuffer(renderbuffer: Renderbuffer) = gl.glDeleteRenderbuffers(1, intArrayOf(renderbuffer), 0)
+    override fun framebufferRenderbuffer(target: Int, attachment: Int, renderbuffertarget: Int, renderbuffer: Renderbuffer) = gl.glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
+    override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = gl.glIsRenderbuffer(renderbuffer)
+    override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = gl.glRenderbufferStorage(target, internalformat, width, height)
+
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
+        when (buffer) {
+            is java.nio.Buffer -> gl.glReadPixels(x, y, width, height, format, type, buffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        }
+    }
 }
 
 fun imageToByteBuffer(image: BufferedImage) : ByteBuffer {

--- a/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
+++ b/kgl-jogl/src/main/kotlin/com/danielgergely/kgl/KglJogl.kt
@@ -188,6 +188,17 @@ class KglJogl(@JvmField private val gl: GL) : Kgl {
 
     override fun texParameteri(target: Int, pname: Int, value: Int) = gl.glTexParameteri(target, pname, value)
 
+    override fun createVertexArray(): VertexArrayObject?
+    {
+        val ints = IntArray(1)
+        gl.glGenVertexArrays(1, ints, 0)
+        return ints[0]
+    }
+    override fun bindVertexArray(vertexArrayObject: VertexArrayObject?)
+            = gl.glBindVertexArray(vertexArrayObject ?: 0)
+    override fun deleteVertexArray(vertexArrayObject: VertexArrayObject)
+            = gl.glDeleteVertexArrays(1, intArrayOf(vertexArrayObject), 0)
+
     override fun drawArrays(mode: Int, first: Int, count: Int) = gl.glDrawArrays(mode, first, count)
 
     override fun getError(): Int = gl.glGetError()

--- a/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
+++ b/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
@@ -45,13 +45,14 @@ class KglLwjgl : Kgl {
         GL.glBindTexture(target, texture ?: 0)
     }
 
-    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int) {
-        //TODO this may be problematic
-        val buffer = sourceData.buffer
-        when (buffer) {
-            is ByteBuffer -> GL.glBufferData(target, buffer, usage)
-            is FloatBuffer -> GL.glBufferData(target, buffer, usage)
-            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int, offset: Int) {
+        sourceData.withIoBuffer(offset) { buffer ->
+            //TODO this may be problematic
+            when (buffer) {
+                is ByteBuffer -> GL.glBufferData(target, buffer, usage)
+                is FloatBuffer -> GL.glBufferData(target, buffer, usage)
+                else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+            }
         }
     }
 
@@ -170,15 +171,16 @@ class KglLwjgl : Kgl {
         GL.glTexImage2D(target, level, internalFormat, width.get(), height.get(), border, GL_RGBA, GL_UNSIGNED_BYTE, data)
     }
 
-    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
-        val wrappedBuffer = buffer.buffer
-        when (wrappedBuffer) {
-            is ByteBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
-            is ShortBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
-            is IntBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
-            is FloatBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
-            is DoubleBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${wrappedBuffer.javaClass}")
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withIoBuffer(offset) { ioBuffer ->
+            when (ioBuffer) {
+                is ByteBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, ioBuffer)
+                is ShortBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, ioBuffer)
+                is IntBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, ioBuffer)
+                is FloatBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, ioBuffer)
+                is DoubleBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, ioBuffer)
+                else -> throw IllegalArgumentException("unknown buffer type ${ioBuffer.javaClass}")
+            }
         }
     }
 
@@ -266,14 +268,15 @@ class KglLwjgl : Kgl {
     override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = GL.glIsRenderbuffer(renderbuffer)
     override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = GL.glRenderbufferStorage(target, internalformat, width, height)
 
-    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
-        val wrappedBuffer = buffer.buffer
-        when (wrappedBuffer) {
-            is ByteBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
-            is ShortBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
-            is IntBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
-            is FloatBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${wrappedBuffer.javaClass}")
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withIoBuffer(offset) { ioBuffer ->
+            when (ioBuffer) {
+                is ByteBuffer -> GL.glReadPixels(x, y, width, height, format, type, ioBuffer)
+                is ShortBuffer -> GL.glReadPixels(x, y, width, height, format, type, ioBuffer)
+                is IntBuffer -> GL.glReadPixels(x, y, width, height, format, type, ioBuffer)
+                is FloatBuffer -> GL.glReadPixels(x, y, width, height, format, type, ioBuffer)
+                else -> throw IllegalArgumentException("unknown buffer type ${ioBuffer.javaClass}")
+            }
         }
     }
 

--- a/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
+++ b/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
@@ -256,7 +256,7 @@ class KglLwjgl : Kgl {
     override fun isFramebuffer(framebuffer: Framebuffer): Boolean = GL.glIsFramebuffer(framebuffer)
 
     override fun bindRenderbuffer(target: Int, renderbuffer: Renderbuffer?) = GL.glBindRenderbuffer(target, renderbuffer ?: 0)
-    override fun createRenderbuffer(): Renderbuffer? = GL.glGenFramebuffers()
+    override fun createRenderbuffer(): Renderbuffer? = GL.glGenRenderbuffers()
     override fun deleteRenderbuffer(renderbuffer: Renderbuffer) = GL.glDeleteRenderbuffers(renderbuffer)
     override fun framebufferRenderbuffer(target: Int, attachment: Int, renderbuffertarget: Int, renderbuffer: Renderbuffer) = GL.glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
     override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = GL.glIsRenderbuffer(renderbuffer)

--- a/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
+++ b/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
@@ -4,7 +4,8 @@ import org.lwjgl.BufferUtils
 import org.lwjgl.opengl.GL33
 import org.lwjgl.stb.STBImage
 import java.io.InputStream
-import java.nio.ByteBuffer
+import java.nio.*
+import java.nio.FloatBuffer
 
 typealias GL = GL33
 
@@ -44,7 +45,13 @@ class KglLwjgl : Kgl {
     }
 
     override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int) {
-        GL.glBufferData(target, sourceData.buffer, usage) //TODO this may be problematic
+        //TODO this may be problematic
+        val buffer = sourceData.buffer
+        when (buffer) {
+            is ByteBuffer -> GL.glBufferData(target, buffer, usage)
+            is FloatBuffer -> GL.glBufferData(target, buffer, usage)
+            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        }
     }
 
     override fun clear(mask: Int) {
@@ -162,6 +169,17 @@ class KglLwjgl : Kgl {
         GL.glTexImage2D(target, level, internalFormat, width.get(), height.get(), border, GL_RGBA, GL_UNSIGNED_BYTE, data)
     }
 
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
+        when (buffer) {
+            is ByteBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
+            is ShortBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
+            is IntBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
+            is FloatBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
+            is DoubleBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        }
+    }
+
     override fun texParameteri(target: Int, pname: Int, value: Int) {
         GL.glTexParameteri(target, pname, value)
     }
@@ -226,6 +244,30 @@ class KglLwjgl : Kgl {
 
     override fun viewport(x: Int, y: Int, width: Int, height: Int) {
         GL.glViewport(x, y, width, height)
+    }
+
+    override fun bindFramebuffer(target: Int, framebuffer: Framebuffer?) = GL.glBindFramebuffer(target, framebuffer ?: 0)
+    override fun createFramebuffer(): Framebuffer? = GL.glGenFramebuffers()
+    override fun deleteFramebuffer(framebuffer: Framebuffer) = GL.glDeleteFramebuffers(framebuffer)
+    override fun checkFramebufferStatus(target: Int): Int = GL.glCheckFramebufferStatus(target)
+    override fun framebufferTexture2D(target: Int, attachment: Int, textarget: Int, texture: Texture, level: Int) = GL.glFramebufferTexture2D(target, attachment, textarget, texture, level)
+    override fun isFramebuffer(framebuffer: Framebuffer): Boolean = GL.glIsFramebuffer(framebuffer)
+
+    override fun bindRenderbuffer(target: Int, renderbuffer: Renderbuffer?) = GL.glBindRenderbuffer(target, renderbuffer ?: 0)
+    override fun createRenderbuffer(): Renderbuffer? = GL.glGenFramebuffers()
+    override fun deleteRenderbuffer(renderbuffer: Renderbuffer) = GL.glDeleteRenderbuffers(renderbuffer)
+    override fun framebufferRenderbuffer(target: Int, attachment: Int, renderbuffertarget: Int, renderbuffer: Renderbuffer) = GL.glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
+    override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = GL.glIsRenderbuffer(renderbuffer)
+    override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = GL.glRenderbufferStorage(target, internalformat, width, height)
+
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
+        when (buffer) {
+            is ByteBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
+            is ShortBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
+            is IntBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
+            is FloatBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        }
     }
 
 }

--- a/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
+++ b/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
@@ -250,7 +250,7 @@ class KglLwjgl : Kgl {
         GL.glViewport(x, y, width, height)
     }
 
-    override fun createVertexArray(): VertexArrayObject? = GL.glGenVertexArrays()
+    override fun createVertexArray(): VertexArrayObject = GL.glGenVertexArrays()
     override fun bindVertexArray(vertexArrayObject: VertexArrayObject?) = GL.glBindVertexArray(vertexArrayObject ?: 0)
     override fun deleteVertexArray(vertexArrayObject: VertexArrayObject) = GL.glDeleteVertexArrays(vertexArrayObject)
 

--- a/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
+++ b/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
@@ -248,6 +248,10 @@ class KglLwjgl : Kgl {
         GL.glViewport(x, y, width, height)
     }
 
+    override fun createVertexArray(): VertexArrayObject? = GL.glGenVertexArrays()
+    override fun bindVertexArray(vertexArrayObject: VertexArrayObject?) = GL.glBindVertexArray(vertexArrayObject ?: 0)
+    override fun deleteVertexArray(vertexArrayObject: VertexArrayObject) = GL.glDeleteVertexArrays(vertexArrayObject)
+
     override fun bindFramebuffer(target: Int, framebuffer: Framebuffer?) = GL.glBindFramebuffer(target, framebuffer ?: 0)
     override fun createFramebuffer(): Framebuffer? = GL.glGenFramebuffers()
     override fun deleteFramebuffer(framebuffer: Framebuffer) = GL.glDeleteFramebuffers(framebuffer)

--- a/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
+++ b/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
@@ -5,6 +5,7 @@ import org.lwjgl.opengl.GL33
 import org.lwjgl.stb.STBImage
 import java.io.InputStream
 import java.nio.*
+import java.nio.ByteBuffer
 import java.nio.FloatBuffer
 
 typealias GL = GL33

--- a/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
+++ b/kgl-lwjgl/src/main/kotlin/com/danielgergely/kgl/KglLwjgl.kt
@@ -171,13 +171,14 @@ class KglLwjgl : Kgl {
     }
 
     override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer) {
-        when (buffer) {
-            is ByteBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
-            is ShortBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
-            is IntBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
-            is FloatBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
-            is DoubleBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, buffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        val wrappedBuffer = buffer.buffer
+        when (wrappedBuffer) {
+            is ByteBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
+            is ShortBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
+            is IntBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
+            is FloatBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
+            is DoubleBuffer -> GL.glTexImage2D(target, level, internalFormat, width, height, border, format, type, wrappedBuffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${wrappedBuffer.javaClass}")
         }
     }
 
@@ -262,12 +263,13 @@ class KglLwjgl : Kgl {
     override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = GL.glRenderbufferStorage(target, internalformat, width, height)
 
     override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer) {
-        when (buffer) {
-            is ByteBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
-            is ShortBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
-            is IntBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
-            is FloatBuffer -> GL.glReadPixels(x, y, width, height, format, type, buffer)
-            else -> throw IllegalArgumentException("unknown buffer type ${buffer.javaClass}")
+        val wrappedBuffer = buffer.buffer
+        when (wrappedBuffer) {
+            is ByteBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
+            is ShortBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
+            is IntBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
+            is FloatBuffer -> GL.glReadPixels(x, y, width, height, format, type, wrappedBuffer)
+            else -> throw IllegalArgumentException("unknown buffer type ${wrappedBuffer.javaClass}")
         }
     }
 

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -13,24 +13,25 @@ expect class FloatBuffer : Buffer {
     fun put(floatArray: FloatArray)
     fun put(floatArray: FloatArray, length: Int)
     operator fun set(pos: Int, f: Float)
-    
+
     fun get(): Float
     operator fun get(pos: Int): Float
 }
 
-@ExperimentalUnsignedTypes
-expect class UByteBuffer : Buffer {
-    constructor(buffer: Array<UByte>)
-    constructor(buffer: UByteArray)
+expect class ByteBuffer : Buffer {
+    constructor(buffer: Array<Byte>)
+    constructor(buffer: ByteArray)
     constructor(size: Int)
 
-    fun put(b: UByte)
-    fun put(byteArray: UByteArray)
-    fun put(byteArray: UByteArray, length: Int)
-    operator fun set(pos: Int, b: UByte)
-    
-    fun get(): UByte
-    operator fun get(pos: Int): UByte
+    fun put(b: Byte)
+    fun put(byteArray: ByteArray)
+    fun put(byteArray: ByteArray, length: Int)
+    operator fun set(pos: Int, b: Byte)
+
+    fun get(): Byte
+    operator fun get(pos: Int): Byte
 }
 
+@Deprecated("Use FloatBuffer() or ByteBuffer() instead.",
+        ReplaceWith("FloatBuffer(sizeInBytes / 4)", "com.danielgergely.kgl.FloatBuffer"))
 fun allocate(sizeInBytes: Int): FloatBuffer = FloatBuffer(sizeInBytes / 4)

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -1,11 +1,36 @@
 package com.danielgergely.kgl
 
-expect class Buffer {
-    fun put(f: Float)
-    fun put(floatArray: FloatArray)
-    fun put(floatArray: FloatArray, length: Int)
-
+expect abstract class Buffer {
     fun position(pos: Int)
 }
 
-expect fun allocate(sizeInBytes: Int): Buffer
+expect class FloatBuffer : Buffer {
+    constructor(buffer: Array<Float>)
+    constructor(buffer: FloatArray)
+    constructor(size: Int)
+
+    fun put(f: Float)
+    fun put(floatArray: FloatArray)
+    fun put(floatArray: FloatArray, length: Int)
+    operator fun set(pos: Int, f: Float)
+    
+    fun get(): Float
+    operator fun get(pos: Int): Float
+}
+
+@ExperimentalUnsignedTypes
+expect class UByteBuffer : Buffer {
+    constructor(buffer: Array<UByte>)
+    constructor(buffer: UByteArray)
+    constructor(size: Int)
+
+    fun put(b: UByte)
+    fun put(byteArray: UByteArray)
+    fun put(byteArray: UByteArray, length: Int)
+    operator fun set(pos: Int, b: UByte)
+    
+    fun get(): UByte
+    operator fun get(pos: Int): UByte
+}
+
+fun allocate(sizeInBytes: Int): FloatBuffer = FloatBuffer(sizeInBytes / 4)

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -1,7 +1,7 @@
 package com.danielgergely.kgl
 
 expect abstract class Buffer {
-    abstract var position: Int
+    var position: Int
 }
 
 expect class FloatBuffer : Buffer {
@@ -11,10 +11,12 @@ expect class FloatBuffer : Buffer {
 
     fun put(f: Float)
     fun put(floatArray: FloatArray)
-    fun put(floatArray: FloatArray, length: Int)
+    fun put(floatArray: FloatArray, offset: Int, length: Int)
     operator fun set(pos: Int, f: Float)
 
     fun get(): Float
+    fun get(floatArray: FloatArray)
+    fun get(floatArray: FloatArray, offset: Int, length: Int)
     operator fun get(pos: Int): Float
 }
 
@@ -25,10 +27,12 @@ expect class ByteBuffer : Buffer {
 
     fun put(b: Byte)
     fun put(byteArray: ByteArray)
-    fun put(byteArray: ByteArray, length: Int)
+    fun put(byteArray: ByteArray, offset: Int, length: Int)
     operator fun set(pos: Int, b: Byte)
 
     fun get(): Byte
+    fun get(byteArray: ByteArray)
+    fun get(byteArray: ByteArray, offset: Int, length: Int)
     operator fun get(pos: Int): Byte
 }
 

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -30,7 +30,7 @@ interface Kgl {
 
     fun createBuffers(count: Int): Array<GlBuffer>
     fun bindBuffer(target: Int, bufferId: GlBuffer?)
-    fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int)
+    fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int, offset: Int = 0)
     fun deleteBuffer(buffer: GlBuffer)
 
     fun vertexAttribPointer(location: Int, size: Int, type: Int, normalized: Boolean, stride: Int, offset: Int)
@@ -62,7 +62,7 @@ interface Kgl {
     fun createTextures(n: Int) : Array<Texture>
     fun deleteTexture(texture: Texture)
     fun texImage2D(target: Int, level: Int, internalFormat: Int, border: Int, resource: TextureResource)
-    fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer)
+    fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer, offset: Int = 0)
     fun activeTexture(texture: Int)
     fun bindTexture(target: Int, texture: Texture?)
     fun generateMipmap(target: Int)
@@ -91,5 +91,5 @@ interface Kgl {
     fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean
     fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int)
 
-    fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer)
+    fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer, offset: Int = 0)
 }

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -62,6 +62,7 @@ interface Kgl {
     fun createTextures(n: Int) : Array<Texture>
     fun deleteTexture(texture: Texture)
     fun texImage2D(target: Int, level: Int, internalFormat: Int, border: Int, resource: TextureResource)
+    fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer)
     fun activeTexture(texture: Int)
     fun bindTexture(target: Int, texture: Texture?)
     fun generateMipmap(target: Int)
@@ -71,4 +72,20 @@ interface Kgl {
 
     fun getError(): Int
     fun finish()
+
+    fun bindFramebuffer(target: Int, framebuffer: Framebuffer?)
+    fun createFramebuffer(): Framebuffer?
+    fun deleteFramebuffer(framebuffer: Framebuffer)
+    fun checkFramebufferStatus(target: Int): Int
+    fun framebufferTexture2D(target: Int, attachment: Int, textarget: Int, texture: Texture, level: Int)
+    fun isFramebuffer(framebuffer: Framebuffer): Boolean
+
+    fun bindRenderbuffer(target: Int, renderbuffer: Renderbuffer?)
+    fun createRenderbuffer(): Renderbuffer?
+    fun deleteRenderbuffer(renderbuffer: Renderbuffer)
+    fun framebufferRenderbuffer(target: Int, attachment: Int, renderbuffertarget: Int, renderbuffer: Renderbuffer)
+    fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean
+    fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int)
+
+    fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer)
 }

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -68,7 +68,7 @@ interface Kgl {
     fun generateMipmap(target: Int)
     fun texParameteri(target: Int, pname: Int, value: Int)
 
-    fun createVertexArray(): VertexArrayObject?
+    fun createVertexArray(): VertexArrayObject
     fun bindVertexArray(vertexArrayObject: VertexArrayObject?)
     fun deleteVertexArray(vertexArrayObject: VertexArrayObject)
 

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -68,6 +68,10 @@ interface Kgl {
     fun generateMipmap(target: Int)
     fun texParameteri(target: Int, pname: Int, value: Int)
 
+    fun createVertexArray(): VertexArrayObject?
+    fun bindVertexArray(vertexArrayObject: VertexArrayObject?)
+    fun deleteVertexArray(vertexArrayObject: VertexArrayObject)
+
     fun drawArrays(mode: Int, first: Int, count: Int)
 
     fun getError(): Int

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Types.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Types.kt
@@ -13,6 +13,8 @@ expect fun TextureResource.dispose()
 
 expect class Texture
 
+expect class VertexArrayObject
+
 expect class Framebuffer
 
 expect class Renderbuffer

--- a/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Types.kt
+++ b/kgl/src/commonMain/kotlin/com/danielgergely/kgl/Types.kt
@@ -12,3 +12,7 @@ expect class TextureResource
 expect fun TextureResource.dispose()
 
 expect class Texture
+
+expect class Framebuffer
+
+expect class Renderbuffer

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -37,35 +37,33 @@ actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
     actual operator fun get(pos: Int): Float = floatBuffer[pos]
 }
 
-@ExperimentalUnsignedTypes
-actual class UByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
-    // TODO: yuck!
-    actual constructor(buffer: Array<UByte>) : this(Uint8Array(buffer.toUByteArray().toByteArray().toTypedArray()))
-    actual constructor(buffer: UByteArray) : this(Uint8Array(buffer.toUByteArray().toByteArray().toTypedArray()))
-    actual constructor(size: Int) : this(UByteArray(size))
+actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
+    actual constructor(buffer: Array<Byte>) : this(Uint8Array(buffer))
+    actual constructor(buffer: ByteArray) : this(Uint8Array(buffer.toTypedArray()))
+    actual constructor(size: Int) : this(ByteArray(size))
 
-    private val uByteBuffer: Uint8Array = buffer
+    private val byteBuffer: Uint8Array = buffer
 
-    actual fun put(b: UByte) {
-        uByteBuffer[pos] = b.toByte()
+    actual fun put(b: Byte) {
+        byteBuffer[pos] = b
         pos += 1
     }
 
-    actual fun put(byteArray: UByteArray) = put(byteArray, byteArray.size)
+    actual fun put(byteArray: ByteArray) = put(byteArray, byteArray.size)
 
-    actual fun put(byteArray: UByteArray, length: Int) {
-        (0 until length).forEach { i -> uByteBuffer[pos++] = byteArray[i].toByte() }
+    actual fun put(byteArray: ByteArray, length: Int) {
+        (0 until length).forEach { i -> byteBuffer[pos++] = byteArray[i] }
     }
 
-    actual operator fun set(pos: Int, b: UByte) {
-        uByteBuffer[pos] = b.toByte()
+    actual operator fun set(pos: Int, b: Byte) {
+        byteBuffer[pos] = b
     }
 
-    actual fun get(): UByte {
-        return uByteBuffer[pos].toUByte()
+    actual fun get(): Byte {
+        return byteBuffer[pos]
     }
 
-    actual operator fun get(pos: Int): UByte {
-        return uByteBuffer[pos].toUByte()
+    actual operator fun get(pos: Int): Byte {
+        return byteBuffer[pos]
     }
 }

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -2,8 +2,12 @@ package com.danielgergely.kgl
 
 import org.khronos.webgl.*
 
-actual abstract class Buffer(internal val buffer: ArrayBufferView) {
+actual abstract class Buffer(private val buffer: ArrayBufferView) {
     actual var position: Int = 0
+
+    fun <T> withGlBuffer(offset: Int, fn: (buffer: ArrayBufferView) -> T): T {
+        return fn(buffer.asDynamic().subarray(offset))
+    }
 }
 
 actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
@@ -43,12 +47,12 @@ actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
     actual operator fun get(pos: Int): Float = floatBuffer[pos]
 }
 
-actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
-    actual constructor(buffer: Array<Byte>) : this(Uint8Array(buffer))
-    actual constructor(buffer: ByteArray) : this(Uint8Array(buffer.toTypedArray()))
+actual class ByteBuffer constructor(buffer: Int8Array) : Buffer(buffer) {
+    actual constructor(buffer: Array<Byte>) : this(Int8Array(buffer))
+    actual constructor(buffer: ByteArray) : this(Int8Array(buffer.toTypedArray()))
     actual constructor(size: Int) : this(ByteArray(size))
 
-    private val byteBuffer: Uint8Array = buffer
+    private val byteBuffer: Int8Array = buffer
 
     actual fun put(b: Byte) {
         byteBuffer[position] = b
@@ -58,7 +62,7 @@ actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
     actual fun put(byteArray: ByteArray) = put(byteArray, 0, byteArray.size)
 
     actual fun put(byteArray: ByteArray, offset: Int, length: Int) {
-        buffer.asDynamic().set(byteArray.asDynamic().subarray(0, length), position)
+        byteBuffer.set(byteArray.unsafeCast<Int8Array>().subarray(offset, length), position)
         position += length
     }
 
@@ -75,7 +79,7 @@ actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
     }
 
     actual fun get(byteArray: ByteArray, offset: Int, length: Int) {
-        val dest = byteArray.unsafeCast<Uint8Array>()
+        val dest = byteArray.unsafeCast<Int8Array>()
         dest.subarray(offset, length).set(byteBuffer, position)
     }
 

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -47,12 +47,12 @@ actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
     actual operator fun get(pos: Int): Float = floatBuffer[pos]
 }
 
-actual class ByteBuffer constructor(buffer: Int8Array) : Buffer(buffer) {
-    actual constructor(buffer: Array<Byte>) : this(Int8Array(buffer))
-    actual constructor(buffer: ByteArray) : this(Int8Array(buffer.toTypedArray()))
+actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
+    actual constructor(buffer: Array<Byte>) : this(Uint8Array(buffer))
+    actual constructor(buffer: ByteArray) : this(Uint8Array(buffer.toTypedArray()))
     actual constructor(size: Int) : this(ByteArray(size))
 
-    private val byteBuffer: Int8Array = buffer
+    private val byteBuffer: Uint8Array = buffer
 
     actual fun put(b: Byte) {
         byteBuffer[position] = b
@@ -62,7 +62,7 @@ actual class ByteBuffer constructor(buffer: Int8Array) : Buffer(buffer) {
     actual fun put(byteArray: ByteArray) = put(byteArray, 0, byteArray.size)
 
     actual fun put(byteArray: ByteArray, offset: Int, length: Int) {
-        byteBuffer.set(byteArray.unsafeCast<Int8Array>().subarray(offset, length), position)
+        byteBuffer.set(byteArray.unsafeCast<Uint8Array>().subarray(offset, length), position)
         position += length
     }
 
@@ -79,7 +79,7 @@ actual class ByteBuffer constructor(buffer: Int8Array) : Buffer(buffer) {
     }
 
     actual fun get(byteArray: ByteArray, offset: Int, length: Int) {
-        val dest = byteArray.unsafeCast<Int8Array>()
+        val dest = byteArray.unsafeCast<Uint8Array>()
         dest.subarray(offset, length).set(byteBuffer, position)
     }
 

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -25,7 +25,8 @@ actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
     actual fun put(floatArray: FloatArray) = put(floatArray, floatArray.size)
 
     actual fun put(floatArray: FloatArray, length: Int) {
-        (0 until length).forEach { i -> floatBuffer[pos++] = floatArray[i] }
+        buffer.asDynamic().set(floatArray.asDynamic().subarray(0, length), pos)
+        pos += length
     }
 
     actual operator fun set(pos: Int, f: Float) {
@@ -52,7 +53,8 @@ actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
     actual fun put(byteArray: ByteArray) = put(byteArray, byteArray.size)
 
     actual fun put(byteArray: ByteArray, length: Int) {
-        (0 until length).forEach { i -> byteBuffer[pos++] = byteArray[i] }
+        buffer.asDynamic().set(byteArray.asDynamic().subarray(0, length), pos)
+        pos += length
     }
 
     actual operator fun set(pos: Int, b: Byte) {

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -3,7 +3,7 @@ package com.danielgergely.kgl
 import org.khronos.webgl.*
 
 actual abstract class Buffer(internal val buffer: ArrayBufferView) {
-    actual abstract var position: Int
+    actual var position: Int = 0
 }
 
 actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
@@ -12,17 +12,16 @@ actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
     actual constructor(size: Int) : this(FloatArray(size))
 
     private val floatBuffer: Float32Array = buffer
-    override var position = 0
 
     actual fun put(f: Float) {
         floatBuffer[position] = f
         position += 1
     }
 
-    actual fun put(floatArray: FloatArray) = put(floatArray, floatArray.size)
+    actual fun put(floatArray: FloatArray) = put(floatArray, 0, floatArray.size)
 
-    actual fun put(floatArray: FloatArray, length: Int) {
-        buffer.asDynamic().set(floatArray.asDynamic().subarray(0, length), position)
+    actual fun put(floatArray: FloatArray, offset: Int, length: Int) {
+        floatBuffer.set((floatArray.unsafeCast<Float32Array>()).subarray(offset, length), position)
         position += length
     }
 
@@ -31,6 +30,15 @@ actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
     }
 
     actual fun get(): Float = floatBuffer[position]
+
+    actual fun get(floatArray: FloatArray) {
+        get(floatArray, 0, floatArray.size)
+    }
+
+    actual fun get(floatArray: FloatArray, offset: Int, length: Int) {
+        val dest = floatArray.unsafeCast<Float32Array>()
+        dest.subarray(offset, length).set(floatBuffer, position)
+    }
 
     actual operator fun get(pos: Int): Float = floatBuffer[pos]
 }
@@ -41,16 +49,15 @@ actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
     actual constructor(size: Int) : this(ByteArray(size))
 
     private val byteBuffer: Uint8Array = buffer
-    override var position = 0
 
     actual fun put(b: Byte) {
         byteBuffer[position] = b
         position += 1
     }
 
-    actual fun put(byteArray: ByteArray) = put(byteArray, byteArray.size)
+    actual fun put(byteArray: ByteArray) = put(byteArray, 0, byteArray.size)
 
-    actual fun put(byteArray: ByteArray, length: Int) {
+    actual fun put(byteArray: ByteArray, offset: Int, length: Int) {
         buffer.asDynamic().set(byteArray.asDynamic().subarray(0, length), position)
         position += length
     }
@@ -61,6 +68,15 @@ actual class ByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
 
     actual fun get(): Byte {
         return byteBuffer[position]
+    }
+
+    actual fun get(byteArray: ByteArray) {
+        get(byteArray, 0, byteArray.size)
+    }
+
+    actual fun get(byteArray: ByteArray, offset: Int, length: Int) {
+        val dest = byteArray.unsafeCast<Uint8Array>()
+        dest.subarray(offset, length).set(byteBuffer, position)
     }
 
     actual operator fun get(pos: Int): Byte {

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -2,10 +2,10 @@ package com.danielgergely.kgl
 
 import org.khronos.webgl.*
 
-actual abstract class Buffer(private val buffer: ArrayBufferView) {
+actual abstract class Buffer(val buffer: ArrayBufferView) {
     actual var position: Int = 0
 
-    fun <T> withGlBuffer(offset: Int, fn: (buffer: ArrayBufferView) -> T): T {
+    inline fun <T> withGlBuffer(offset: Int, fn: (buffer: ArrayBufferView) -> T): T {
         return fn(buffer.asDynamic().subarray(offset))
     }
 }

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -1,27 +1,71 @@
 package com.danielgergely.kgl
 
-import org.khronos.webgl.Float32Array
+import org.khronos.webgl.*
 
-actual class Buffer(buffer: FloatArray) {
-    val buffer: dynamic = buffer
-    var pos: dynamic = 0
+actual abstract class Buffer(internal val buffer: ArrayBufferView) {
+    protected var pos: Int = 0
+
+    actual fun position(pos: Int) {
+        this.pos = pos
+    }
+}
+
+actual class FloatBuffer constructor(buffer: Float32Array) : Buffer(buffer) {
+    actual constructor(buffer: Array<Float>) : this(Float32Array(buffer))
+    actual constructor(buffer: FloatArray) : this(Float32Array(buffer.toTypedArray()))
+    actual constructor(size: Int) : this(FloatArray(size))
+
+    private val floatBuffer: Float32Array = buffer
 
     actual fun put(f: Float) {
-        buffer[pos] = f
+        floatBuffer[pos] = f
         pos += 1
     }
 
     actual fun put(floatArray: FloatArray) = put(floatArray, floatArray.size)
 
-    actual fun put(floatArray: dynamic, length: Int) {
-        buffer.set(floatArray.subarray(0, length), pos)
-        pos += length
+    actual fun put(floatArray: FloatArray, length: Int) {
+        (0 until length).forEach { i -> floatBuffer[pos++] = floatArray[i] }
     }
 
-    actual fun position(pos: Int) {
-        this.pos = pos / Float32Array.BYTES_PER_ELEMENT
+    actual operator fun set(pos: Int, f: Float) {
+        floatBuffer[pos] = f
     }
 
+    actual fun get(): Float = floatBuffer[pos]
+
+    actual operator fun get(pos: Int): Float = floatBuffer[pos]
 }
 
-actual fun allocate(sizeInBytes: Int): Buffer = Buffer(FloatArray(sizeInBytes / Float32Array.BYTES_PER_ELEMENT))
+@ExperimentalUnsignedTypes
+actual class UByteBuffer constructor(buffer: Uint8Array) : Buffer(buffer) {
+    // TODO: yuck!
+    actual constructor(buffer: Array<UByte>) : this(Uint8Array(buffer.toUByteArray().toByteArray().toTypedArray()))
+    actual constructor(buffer: UByteArray) : this(Uint8Array(buffer.toUByteArray().toByteArray().toTypedArray()))
+    actual constructor(size: Int) : this(UByteArray(size))
+
+    private val uByteBuffer: Uint8Array = buffer
+
+    actual fun put(b: UByte) {
+        uByteBuffer[pos] = b.toByte()
+        pos += 1
+    }
+
+    actual fun put(byteArray: UByteArray) = put(byteArray, byteArray.size)
+
+    actual fun put(byteArray: UByteArray, length: Int) {
+        (0 until length).forEach { i -> uByteBuffer[pos++] = byteArray[i].toByte() }
+    }
+
+    actual operator fun set(pos: Int, b: UByte) {
+        uByteBuffer[pos] = b.toByte()
+    }
+
+    actual fun get(): UByte {
+        return uByteBuffer[pos].toUByte()
+    }
+
+    actual operator fun get(pos: Int): UByte {
+        return uByteBuffer[pos].toUByte()
+    }
+}

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -91,6 +91,8 @@ class KglJs(private val gl: WebGLRenderingContext) : Kgl  {
     override fun deleteTexture(texture: Texture) = gl.deleteTexture(texture.unsafeCast<WebGLTexture>())
     override fun texImage2D(target: Int, level: Int, internalFormat: Int, border: Int, resource: TextureResource)
             = gl.texImage2D(target, level, internalFormat, GL_RGBA, GL_UNSIGNED_BYTE, resource.image)
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer)
+            = gl.texImage2D(target, level, internalFormat, width, height, border, format, type, buffer.buffer.unsafeCast<ArrayBufferView>())
 
 
     override fun activeTexture(texture: Int) = gl.activeTexture(texture)
@@ -102,4 +104,21 @@ class KglJs(private val gl: WebGLRenderingContext) : Kgl  {
 
     override fun getError(): Int = gl.getError()
     override fun finish() = gl.finish()
+
+    override fun bindFramebuffer(target: Int, framebuffer: Framebuffer?) = gl.bindFramebuffer(target, framebuffer.unsafeCast<WebGLFramebuffer>())
+    override fun createFramebuffer(): Framebuffer? = gl.createFramebuffer()
+    override fun deleteFramebuffer(framebuffer: Framebuffer) = gl.deleteFramebuffer(framebuffer.unsafeCast<WebGLFramebuffer>())
+    override fun checkFramebufferStatus(target: Int): Int = gl.checkFramebufferStatus(target)
+    override fun framebufferTexture2D(target: Int, attachment: Int, textarget: Int, texture: Texture, level: Int) = gl.framebufferTexture2D(target, attachment, textarget, texture.unsafeCast<WebGLTexture>(), level)
+    override fun isFramebuffer(framebuffer: Framebuffer): Boolean = gl.isFramebuffer(framebuffer.unsafeCast<WebGLFramebuffer>())
+
+    override fun bindRenderbuffer(target: Int, renderbuffer: Renderbuffer?) = gl.bindRenderbuffer(target, renderbuffer.unsafeCast<WebGLRenderbuffer>())
+    override fun createRenderbuffer(): Renderbuffer? = gl.createRenderbuffer()
+    override fun deleteRenderbuffer(renderbuffer: Renderbuffer) = gl.deleteRenderbuffer(renderbuffer.unsafeCast<WebGLRenderbuffer>())
+    override fun framebufferRenderbuffer(target: Int, attachment: Int, renderbuffertarget: Int, renderbuffer: Renderbuffer) = gl.framebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer.unsafeCast<WebGLRenderbuffer>())
+    override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = gl.isRenderbuffer(renderbuffer.unsafeCast<WebGLRenderbuffer>())
+    override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = gl.renderbufferStorage(target, internalformat, width, height)
+
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer)
+            = gl.readPixels(x, y, width, height, format, type, buffer.buffer.unsafeCast<ArrayBufferView>())
 }

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -104,8 +104,7 @@ class KglJs(private val gl: WebGLRenderingContext) : Kgl  {
     override fun generateMipmap(target: Int) = gl.generateMipmap(target)
     override fun texParameteri(target: Int, pname: Int, value: Int) = gl.texParameteri(target, pname, value)
 
-    override fun createVertexArray(): VertexArrayObject?
-            = (gl as WebGL2RenderingContext).createVertexArray()
+    override fun createVertexArray(): VertexArrayObject = (gl as WebGL2RenderingContext).createVertexArray() ?: throw Exception()
     override fun bindVertexArray(vertexArrayObject: VertexArrayObject?)
             = (gl as WebGL2RenderingContext).bindVertexArray(vertexArrayObject.unsafeCast<WebGLVertexArrayObject>())
     override fun deleteVertexArray(vertexArrayObject: VertexArrayObject)

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -49,9 +49,10 @@ class KglJs(private val gl: WebGLRenderingContext) : Kgl  {
     override fun createBuffers(count: Int): Array<GlBuffer> = Array(count) { gl.createBuffer() ?: throw Exception() }
 
     override fun bindBuffer(target: Int, bufferId: GlBuffer?) = gl.bindBuffer(target, bufferId.unsafeCast<WebGLBuffer>())
-    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int) {
-        val buffer: dynamic = sourceData.buffer
-        gl.bufferData(target, buffer.unsafeCast<BufferDataSource>(), usage)
+    override fun bufferData(target: Int, sourceData: Buffer, size: Int, usage: Int, offset: Int) {
+        sourceData.withGlBuffer(offset) { glBuffer ->
+            gl.bufferData(target, glBuffer, usage)
+        }
     }
 
     override fun deleteBuffer(buffer: GlBuffer) = gl.deleteBuffer(buffer.unsafeCast<WebGLBuffer>())
@@ -91,8 +92,11 @@ class KglJs(private val gl: WebGLRenderingContext) : Kgl  {
     override fun deleteTexture(texture: Texture) = gl.deleteTexture(texture.unsafeCast<WebGLTexture>())
     override fun texImage2D(target: Int, level: Int, internalFormat: Int, border: Int, resource: TextureResource)
             = gl.texImage2D(target, level, internalFormat, GL_RGBA, GL_UNSIGNED_BYTE, resource.image)
-    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer)
-            = gl.texImage2D(target, level, internalFormat, width, height, border, format, type, buffer.buffer.asDynamic().subarray(buffer.position))
+    override fun texImage2D(target: Int, level: Int, internalFormat: Int, width: Int, height: Int, border: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withGlBuffer(offset) { glBuffer ->
+            gl.texImage2D(target, level, internalFormat, width, height, border, format, type, glBuffer)
+        }
+    }
 
 
     override fun activeTexture(texture: Int) = gl.activeTexture(texture)
@@ -126,6 +130,9 @@ class KglJs(private val gl: WebGLRenderingContext) : Kgl  {
     override fun isRenderbuffer(renderbuffer: Renderbuffer): Boolean = gl.isRenderbuffer(renderbuffer.unsafeCast<WebGLRenderbuffer>())
     override fun renderbufferStorage(target: Int, internalformat: Int, width: Int, height: Int) = gl.renderbufferStorage(target, internalformat, width, height)
 
-    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer)
-            = gl.readPixels(x, y, width, height, format, type, buffer.buffer.unsafeCast<ArrayBufferView>())
+    override fun readPixels(x: Int, y: Int, width: Int, height: Int, format: Int, type: Int, buffer: Buffer, offset: Int) {
+        buffer.withGlBuffer(offset) { glBuffer ->
+            gl.readPixels(x, y, width, height, format, type, glBuffer)
+        }
+    }
 }

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Kgl.kt
@@ -100,6 +100,13 @@ class KglJs(private val gl: WebGLRenderingContext) : Kgl  {
     override fun generateMipmap(target: Int) = gl.generateMipmap(target)
     override fun texParameteri(target: Int, pname: Int, value: Int) = gl.texParameteri(target, pname, value)
 
+    override fun createVertexArray(): VertexArrayObject?
+            = (gl as WebGL2RenderingContext).createVertexArray()
+    override fun bindVertexArray(vertexArrayObject: VertexArrayObject?)
+            = (gl as WebGL2RenderingContext).bindVertexArray(vertexArrayObject.unsafeCast<WebGLVertexArrayObject>())
+    override fun deleteVertexArray(vertexArrayObject: VertexArrayObject)
+            = (gl as WebGL2RenderingContext).deleteVertexArray(vertexArrayObject.unsafeCast<WebGLVertexArrayObject>())
+
     override fun drawArrays(mode: Int, first: Int, count: Int) = gl.drawArrays(mode, first, count)
 
     override fun getError(): Int = gl.getError()

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Types.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Types.kt
@@ -32,6 +32,9 @@ actual typealias GlBuffer = Any
  */
 actual typealias Texture = Any
 
+/** Must be [WebGLVertexArrayObject] */
+actual typealias VertexArrayObject = Any
+
 /** Must be [WebGLFramebuffer] */
 actual typealias Framebuffer = Any
 

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Types.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Types.kt
@@ -31,3 +31,9 @@ actual typealias GlBuffer = Any
  * Must be [WebGLTexture]
  */
 actual typealias Texture = Any
+
+/** Must be [WebGLFramebuffer] */
+actual typealias Framebuffer = Any
+
+/** Must be [WebGLRenderbuffer] */
+actual typealias Renderbuffer = Any

--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/WebGL2.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/WebGL2.kt
@@ -1,0 +1,13 @@
+package com.danielgergely.kgl
+
+import org.khronos.webgl.WebGLObject
+import org.khronos.webgl.WebGLRenderingContext
+
+public external abstract class WebGL2RenderingContext : WebGLRenderingContext {
+    fun createVertexArray(): WebGLVertexArrayObject?
+    fun bindVertexArray(vertexArray: WebGLVertexArrayObject)
+    fun deleteVertexArray(vertexArray: WebGLVertexArrayObject)
+}
+
+public external class WebGLVertexArrayObject : WebGLObject {
+}

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -4,14 +4,14 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.FloatBuffer
 
-actual abstract class Buffer(@JvmField private val buffer: java.nio.Buffer) {
+actual abstract class Buffer(@JvmField val buffer: java.nio.Buffer) {
     actual var position: Int
         get() = buffer.position()
         set(value) {
             buffer.position(value)
         }
 
-    fun <T> withIoBuffer(offset: Int, fn: (buffer: java.nio.Buffer) -> T): T {
+    inline fun <T> withIoBuffer(offset: Int, fn: (buffer: java.nio.Buffer) -> T): T {
         val origPosition = this.position
         this.position = offset
         try {

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -41,7 +41,7 @@ actual class FloatBuffer private constructor(buffer: FloatBuffer): Buffer(buffer
     actual fun put(floatArray: FloatArray) = put(floatArray, 0, floatArray.size)
 
     actual fun put(floatArray: FloatArray, offset: Int, length: Int) {
-        floatBuffer.put(floatArray, 0, floatArray.size)
+        floatBuffer.put(floatArray, offset, length)
     }
 
     actual operator fun set(pos: Int, f: Float) {
@@ -80,7 +80,7 @@ actual class ByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) 
     actual fun put(byteArray: ByteArray) = put(byteArray, 0, byteArray.size)
 
     actual fun put(byteArray: ByteArray, offset: Int, length: Int) {
-        byteBuffer.put(byteArray, 0, byteArray.size)
+        byteBuffer.put(byteArray, offset, length)
     }
 
     actual operator fun set(pos: Int, b: Byte) {

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -2,22 +2,75 @@ package com.danielgergely.kgl
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.nio.FloatBuffer
 
-actual class Buffer(@JvmField val buffer: ByteBuffer) {
-    actual fun put(f: Float) {
-        buffer.putFloat(f)
-    }
-
-    actual fun put(floatArray: FloatArray) = put(floatArray, floatArray.size)
-
-    actual fun put(floatArray: FloatArray, length: Int) {
-        buffer.asFloatBuffer().put(floatArray, 0, length)
-    }
-
+actual abstract class Buffer(@JvmField val buffer: java.nio.Buffer) {
     actual fun position(pos: Int) {
         buffer.position(pos)
     }
 }
 
-actual fun allocate(sizeInBytes: Int): Buffer =
-    Buffer(ByteBuffer.allocateDirect(sizeInBytes).order(ByteOrder.nativeOrder()))
+actual class FloatBuffer private constructor(buffer: FloatBuffer): Buffer(buffer) {
+    actual constructor(buffer: Array<Float>) : this(alloc(buffer.size).also { it.put(buffer.toFloatArray()) })
+    actual constructor(buffer: FloatArray) : this(alloc(buffer.size).also { it.put(buffer) })
+    actual constructor(size: Int) : this(alloc(size))
+
+    companion object {
+        private fun alloc(size: Int) =
+                ByteBuffer.allocateDirect(size * 4).order(ByteOrder.nativeOrder()).asFloatBuffer()
+    }
+
+    private val floatBuffer: FloatBuffer = super.buffer as FloatBuffer
+
+    actual fun put(f: Float) {
+        floatBuffer.put(f)
+    }
+
+    actual fun put(floatArray: FloatArray) = put(floatArray, floatArray.size)
+
+    actual fun put(floatArray: FloatArray, length: Int) {
+        (0 until length).forEach { i -> floatBuffer.put(floatArray[i]) }
+    }
+
+    actual operator fun set(pos: Int, f: Float) {
+        floatBuffer.put(pos, f)
+    }
+
+    actual fun get(): Float = floatBuffer.get()
+
+    actual operator fun get(pos: Int): Float = floatBuffer.get(pos)
+
+}
+
+@ExperimentalUnsignedTypes
+actual class UByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) {
+    actual constructor(buffer: Array<UByte>) : this(alloc(buffer.size).also { it.put(buffer.toUByteArray().toByteArray()) })
+    actual constructor(buffer: UByteArray) : this(alloc(buffer.size).also { it.put(buffer.toByteArray()) })
+    actual constructor(size: Int) : this(alloc(size))
+
+    companion object {
+        private fun alloc(size: Int) =
+                ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder())
+    }
+
+    private val uByteBuffer: ByteBuffer = buffer
+
+    actual fun put(b: UByte) {
+        uByteBuffer.put(b.toByte())
+    }
+
+    actual fun put(byteArray: UByteArray) = put(byteArray, byteArray.size)
+
+    actual fun put(byteArray: UByteArray, length: Int) {
+        (0 until length).forEach { i -> uByteBuffer.put(byteArray[i].toByte()) }
+    }
+
+    actual operator fun set(pos: Int, b: UByte) {
+        uByteBuffer.put(pos, b.toByte())
+    }
+
+    actual fun get(): UByte = uByteBuffer.get().toUByte()
+
+    actual operator fun get(pos: Int): UByte = uByteBuffer.get(pos).toUByte()
+
+}

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -42,10 +42,9 @@ actual class FloatBuffer private constructor(buffer: FloatBuffer): Buffer(buffer
 
 }
 
-@ExperimentalUnsignedTypes
-actual class UByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) {
-    actual constructor(buffer: Array<UByte>) : this(alloc(buffer.size).also { it.put(buffer.toUByteArray().toByteArray()) })
-    actual constructor(buffer: UByteArray) : this(alloc(buffer.size).also { it.put(buffer.toByteArray()) })
+actual class ByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) {
+    actual constructor(buffer: Array<Byte>) : this(alloc(buffer.size).also { it.put(buffer.toByteArray()) })
+    actual constructor(buffer: ByteArray) : this(alloc(buffer.size).also { it.put(buffer) })
     actual constructor(size: Int) : this(alloc(size))
 
     companion object {
@@ -53,24 +52,24 @@ actual class UByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer)
                 ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder())
     }
 
-    private val uByteBuffer: ByteBuffer = buffer
+    private val byteBuffer: ByteBuffer = buffer
 
-    actual fun put(b: UByte) {
-        uByteBuffer.put(b.toByte())
+    actual fun put(b: Byte) {
+        byteBuffer.put(b)
     }
 
-    actual fun put(byteArray: UByteArray) = put(byteArray, byteArray.size)
+    actual fun put(byteArray: ByteArray) = put(byteArray, byteArray.size)
 
-    actual fun put(byteArray: UByteArray, length: Int) {
-        (0 until length).forEach { i -> uByteBuffer.put(byteArray[i].toByte()) }
+    actual fun put(byteArray: ByteArray, length: Int) {
+        (0 until length).forEach { i -> byteBuffer.put(byteArray[i]) }
     }
 
-    actual operator fun set(pos: Int, b: UByte) {
-        uByteBuffer.put(pos, b.toByte())
+    actual operator fun set(pos: Int, b: Byte) {
+        byteBuffer.put(pos, b)
     }
 
-    actual fun get(): UByte = uByteBuffer.get().toUByte()
+    actual fun get(): Byte = byteBuffer.get()
 
-    actual operator fun get(pos: Int): UByte = uByteBuffer.get(pos).toUByte()
+    actual operator fun get(pos: Int): Byte = byteBuffer.get(pos)
 
 }

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -5,7 +5,11 @@ import java.nio.ByteOrder
 import java.nio.FloatBuffer
 
 actual abstract class Buffer(@JvmField val buffer: java.nio.Buffer) {
-    actual abstract var position: Int
+    actual var position: Int
+        get() = buffer.position()
+        set(value) {
+            buffer.position(value)
+        }
 }
 
 actual class FloatBuffer private constructor(buffer: FloatBuffer): Buffer(buffer) {
@@ -24,9 +28,9 @@ actual class FloatBuffer private constructor(buffer: FloatBuffer): Buffer(buffer
         floatBuffer.put(f)
     }
 
-    actual fun put(floatArray: FloatArray) = put(floatArray, floatArray.size)
+    actual fun put(floatArray: FloatArray) = put(floatArray, 0, floatArray.size)
 
-    actual fun put(floatArray: FloatArray, length: Int) {
+    actual fun put(floatArray: FloatArray, offset: Int, length: Int) {
         floatBuffer.put(floatArray, 0, floatArray.size)
     }
 
@@ -36,13 +40,15 @@ actual class FloatBuffer private constructor(buffer: FloatBuffer): Buffer(buffer
 
     actual fun get(): Float = floatBuffer.get()
 
-    actual operator fun get(pos: Int): Float = floatBuffer.get(pos)
+    actual fun get(floatArray: FloatArray) {
+        get(floatArray, 0, floatArray.size)
+    }
 
-    override var position: Int
-        get() = floatBuffer.position()
-        set(value) {
-            floatBuffer.position(value)
-        }
+    actual fun get(floatArray: FloatArray, offset: Int, length: Int) {
+        floatBuffer.get(floatArray, offset, length)
+    }
+
+    actual operator fun get(pos: Int): Float = floatBuffer.get(pos)
 }
 
 actual class ByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) {
@@ -61,9 +67,9 @@ actual class ByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) 
         byteBuffer.put(b)
     }
 
-    actual fun put(byteArray: ByteArray) = put(byteArray, byteArray.size)
+    actual fun put(byteArray: ByteArray) = put(byteArray, 0, byteArray.size)
 
-    actual fun put(byteArray: ByteArray, length: Int) {
+    actual fun put(byteArray: ByteArray, offset: Int, length: Int) {
         byteBuffer.put(byteArray, 0, byteArray.size)
     }
 
@@ -73,11 +79,13 @@ actual class ByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) 
 
     actual fun get(): Byte = byteBuffer.get()
 
-    actual operator fun get(pos: Int): Byte = byteBuffer.get(pos)
+    actual fun get(byteArray: ByteArray) {
+        get(byteArray, 0, byteArray.size)
+    }
 
-    override var position: Int
-        get() = byteBuffer.position()
-        set(value) {
-            byteBuffer.position(value)
-        }
+    actual fun get(byteArray: ByteArray, offset: Int, length: Int) {
+        byteBuffer.get(byteArray, offset, length)
+    }
+
+    actual operator fun get(pos: Int): Byte = byteBuffer.get(pos)
 }

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -29,7 +29,7 @@ actual class FloatBuffer private constructor(buffer: FloatBuffer): Buffer(buffer
     actual fun put(floatArray: FloatArray) = put(floatArray, floatArray.size)
 
     actual fun put(floatArray: FloatArray, length: Int) {
-        (0 until length).forEach { i -> floatBuffer.put(floatArray[i]) }
+        floatBuffer.put(floatArray, 0, floatArray.size)
     }
 
     actual operator fun set(pos: Int, f: Float) {
@@ -61,7 +61,7 @@ actual class ByteBuffer private constructor(buffer: ByteBuffer): Buffer(buffer) 
     actual fun put(byteArray: ByteArray) = put(byteArray, byteArray.size)
 
     actual fun put(byteArray: ByteArray, length: Int) {
-        (0 until length).forEach { i -> byteBuffer.put(byteArray[i]) }
+        byteBuffer.put(byteArray, 0, byteArray.size)
     }
 
     actual operator fun set(pos: Int, b: Byte) {

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Types.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Types.kt
@@ -15,6 +15,8 @@ actual typealias Texture = Int
 actual class TextureResource(@JvmField val encodedPng: InputStream)
 actual fun TextureResource.dispose() = encodedPng.close()
 
+actual typealias VertexArrayObject = Int
+
 actual typealias Framebuffer = Int
 
 actual typealias Renderbuffer = Int

--- a/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Types.kt
+++ b/kgl/src/jvmMain/kotlin/com/danielgergely/kgl/Types.kt
@@ -14,3 +14,7 @@ actual typealias Texture = Int
 
 actual class TextureResource(@JvmField val encodedPng: InputStream)
 actual fun TextureResource.dispose() = encodedPng.close()
+
+actual typealias Framebuffer = Int
+
+actual typealias Renderbuffer = Int


### PR DESCRIPTION
* Add support for `texImage2D` uniforms with non-image data.
* Add `Framebuffer` and `Renderbuffer` support.
* `Buffer` is now abstract and implemented by `FloatBuffer` and `UByteBuffer`,
  which both have reasonable implementations for JS and JVM.
* `Buffer.put(array, length)` now appends at the buffer's current position
  instead of overwriting starting at 0.