### PR TITLE
Make Buffer's backing ArrayBufferView accessible in JS

### DIFF
--- a/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
+++ b/kgl/src/jsMain/kotlin/com/danielgergely/kgl/Buffer.kt
@@ -3,7 +3,7 @@ package com.danielgergely.kgl
 import org.khronos.webgl.*
 
 public actual abstract class Buffer {
-    internal abstract fun getJsBufferWithOffset(): ArrayBufferView
+    public abstract fun getJsBufferWithOffset(): ArrayBufferView
 }
 
 public actual class FloatBuffer constructor(buffer: Float32Array) : Buffer() {


### PR DESCRIPTION
It's necessary in order to use e.g. `getBufferSubData()`, which only exists in webgl2, and was thus a poor candidate for adding to the `Kgl` interface.